### PR TITLE
Improve macOS compatibility for model download scripts

### DIFF
--- a/get_models.sh
+++ b/get_models.sh
@@ -4,13 +4,32 @@
 # Copyright (C) 2025 Apple Inc. All Rights Reserved.
 #
 
+set -euo pipefail
+
+download() {
+    local url="$1"
+    local destination_dir="$2"
+    local filename
+
+    filename=$(basename "$url")
+
+    if command -v wget >/dev/null 2>&1; then
+        wget -q --show-progress "$url" -P "$destination_dir"
+    elif command -v curl >/dev/null 2>&1; then
+        curl -L --progress-bar "$url" -o "$destination_dir/$filename"
+    else
+        echo "Error: neither wget nor curl is available. Please install one of them and retry." >&2
+        exit 1
+    fi
+}
+
 mkdir -p checkpoints
-wget https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_0.5b_stage2.zip -P checkpoints
-wget https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_0.5b_stage3.zip -P checkpoints
-wget https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_1.5b_stage2.zip -P checkpoints
-wget https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_1.5b_stage3.zip -P checkpoints
-wget https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_7b_stage2.zip -P checkpoints
-wget https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_7b_stage3.zip -P checkpoints
+download "https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_0.5b_stage2.zip" checkpoints
+download "https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_0.5b_stage3.zip" checkpoints
+download "https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_1.5b_stage2.zip" checkpoints
+download "https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_1.5b_stage3.zip" checkpoints
+download "https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_7b_stage2.zip" checkpoints
+download "https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_7b_stage3.zip" checkpoints
 
 # Extract models
 cd checkpoints


### PR DESCRIPTION
## Summary
- add cross-platform download helpers that support either wget or curl
- harden temporary directory creation and error handling in the MLX model downloader script

## Testing
- bash -n get_models.sh
- bash -n app/get_pretrained_mlx_model.sh

------
https://chatgpt.com/codex/tasks/task_e_68e468b0c39083338f4f70c867f0840a